### PR TITLE
FF1600 Open Series

### DIFF
--- a/src/data/official-sessions.js
+++ b/src/data/official-sessions.js
@@ -383,6 +383,22 @@ const officials = [
         },
         sessions: []
     },
+        {
+        seriesId: 'ff1600-open',
+        shortLabel: 'FF1600 Open',
+        label: 'Motorsport UK FF 1600 Trophy by Thrustmaster',
+        cars: ["Ray FF1600"],
+        links: {
+            discord: 'https://discord.gg/QZRYvUdYJ6',
+        },
+        sessions: [
+            {
+                sessionDay: FRI,
+                sessionTimeGmt: '20:45',
+                notes: [BROADCAST, SOF]
+            },
+        ]
+    },
 ]
 
 export {

--- a/src/data/official-sessions.js
+++ b/src/data/official-sessions.js
@@ -383,7 +383,7 @@ const officials = [
         },
         sessions: []
     },
-        {
+    {
         seriesId: 'ff1600-open',
         shortLabel: 'FF1600 Open',
         label: 'Motorsport UK FF 1600 Trophy by Thrustmaster',


### PR DESCRIPTION
For a free car, the Ray FF1600 D series is a _remarkably_ low participation series, largely in part to its unusual schedule and direct clash with the Rookie series. Here's the SoF and Discord