### PR TITLE
Correct FF1600 error

### DIFF
--- a/src/data/official-sessions.js
+++ b/src/data/official-sessions.js
@@ -393,7 +393,7 @@ const officials = [
         },
         sessions: [
             {
-                sessionDay: FRI,
+                sessionDay: MON,
                 sessionTimeGmt: '20:45',
                 notes: [BROADCAST, SOF]
             },


### PR DESCRIPTION
Oops: that was really stupid. I run the 1600 broadcast and got the day of the week confused with a other one I run in a bout of madness. Many apologies for the error. It is Mondays. It's always Mondays!!!!