### PR TITLE
Update Clio Cup SOF time

### DIFF
--- a/src/data/official-sessions.js
+++ b/src/data/official-sessions.js
@@ -78,7 +78,7 @@ const officials = [
         sessions: [
             {
                 sessionDay: WED,
-                sessionTimeGmt: '19:00',
+                sessionTimeGmt: '20:00',
                 notes: [SOF]
             },
         ]


### PR DESCRIPTION
Changing the time of the Clio Cup SOF time to adjust for daylight savings.