### PR TITLE
Add calendar download for race series

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,14 +1,18 @@
 import './App.scss';
-import React from 'react';
+import React, { useState } from 'react';
 import { useParams, NavLink, Link } from "react-router-dom";
 import Timeslot from './components/Timeslot/Timeslot.js';
 import {officials} from './data/official-sessions.js';
 import { ReactComponent as DiscordIcon } from './images/Discord-Logo-Color.svg';
 import { ReactComponent as LinkIcon } from './images/link.svg';
+import { ReactComponent as CalendarIcon } from './images/calendar.svg';
+import CalendarModal from './components/CalendarModal/CalendarModal.js';
 
 
 const App = () => {
     let { selected_series } = useParams();
+    const [calendarModalSeriesId, setCalendarModalSeriesId] = useState(null);
+
     const sortedOfficials = officials.slice().sort((a,b) => {
         return a.shortLabel > b.shortLabel ? 1 : -1
     })
@@ -16,8 +20,8 @@ const App = () => {
         return selected_series ? singleSeries.seriesId === selected_series : true
     })
 
-    function renderLinks(links) {
-        return Object.keys(links).map((key) => {
+    function renderLinks(links, seriesId) {
+        const linkElements = Object.keys(links).map((key) => {
             let linkLabel = ''
             let labelClasses = 'text'
             switch(key) {
@@ -43,6 +47,21 @@ const App = () => {
                 </div>
             )
         });
+
+        // Add calendar link
+        linkElements.push(
+            <div key="calendar" className="link-row">
+                <span className="label-type svg calendar"><CalendarIcon /></span>
+                <button
+                    onClick={() => setCalendarModalSeriesId(seriesId)}
+                    className="calendar-link-button"
+                >
+                    Download calendar
+                </button>
+            </div>
+        );
+
+        return linkElements;
     }
 
     return (
@@ -80,9 +99,9 @@ const App = () => {
                                     <div className="cars">
                                         {series.cars.map(car => <span key={`car.${car}`} className="car">{car}</span>)}
                                     </div>
-                                    {series.links && Object.keys(series.links).length > 0 && (
+                                    {((series.links && Object.keys(series.links).length > 0) || (series.sessions && series.sessions.length > 0)) && (
                                         <div className="links">
-                                            {renderLinks(series.links)}
+                                            {renderLinks(series.links || {}, series.seriesId)}
                                         </div>
                                     )}
                                 </header>
@@ -112,6 +131,13 @@ const App = () => {
                     })}
                 </div>
             </div>
+
+            {calendarModalSeriesId && (
+                <CalendarModal
+                    series={officials.find(s => s.seriesId === calendarModalSeriesId)}
+                    onClose={() => setCalendarModalSeriesId(null)}
+                />
+            )}
         </div>
     )
 }

--- a/src/components/CalendarModal/CalendarModal.js
+++ b/src/components/CalendarModal/CalendarModal.js
@@ -1,0 +1,136 @@
+import { useState, useMemo } from 'react';
+import moment from 'moment-timezone';
+import './CalendarModal.scss';
+import { downloadCalendar, isSpecialSession, parseTime, toIsoWeekday } from '../../lib/calendar-helpers.js';
+import { ReactComponent as CalendarIcon } from '../../images/calendar.svg';
+
+const getSessionId = (session) => `${session.sessionDay}-${session.sessionTimeGmt}`;
+
+const CalendarModal = ({ series, onClose }) => {
+    // Pre-select Broadcasted and SOF sessions
+    const defaultSelected = useMemo(() => {
+        const defaults = new Set();
+        series.sessions.forEach(session => {
+            if (isSpecialSession(session)) {
+                defaults.add(getSessionId(session));
+            }
+        });
+        return defaults;
+    }, [series.sessions]);
+
+    const [selectedSessions, setSelectedSessions] = useState(defaultSelected);
+
+    const toggleSession = (sessionId) => {
+        const newSet = new Set(selectedSessions);
+        if (newSet.has(sessionId)) {
+            newSet.delete(sessionId);
+        } else {
+            newSet.add(sessionId);
+        }
+        setSelectedSessions(newSet);
+    };
+
+    const selectAll = () => {
+        const allSessionIds = series.sessions.map(getSessionId);
+        setSelectedSessions(new Set(allSessionIds));
+    };
+
+    const selectNone = () => {
+        setSelectedSessions(new Set());
+    };
+
+    const handleDownload = () => {
+        if (selectedSessions.size === 0) {
+            alert('Please select at least one session');
+            return;
+        }
+
+        try {
+            downloadCalendar(series, selectedSessions);
+            onClose();
+        } catch (error) {
+            alert(error.message || 'Error generating calendar. Please try again.');
+        }
+    };
+
+    // Convert GMT times to user's local time (memoized per session)
+    const localTimeInfoMap = useMemo(() => {
+        const map = new Map();
+        const userTimezone = moment.tz.guess();
+
+        series.sessions.forEach(session => {
+            const { hour, minute } = parseTime(session.sessionTimeGmt);
+
+            // Create a reference moment in GMT for this session, then convert to local
+            const sessionInGmt = moment.tz('GMT')
+                .isoWeekday(toIsoWeekday(session.sessionDay))
+                .hour(hour)
+                .minute(minute)
+                .second(0);
+
+            const sessionInLocalTime = sessionInGmt.clone().tz(userTimezone);
+
+            map.set(getSessionId(session), {
+                dayName: sessionInLocalTime.format('dddd'),
+                time: sessionInLocalTime.format('h:mm A')
+            });
+        });
+        return map;
+    }, [series.sessions]);
+
+    return (
+        <div className="calendar-modal-overlay" onClick={onClose}>
+            <div className="calendar-modal" onClick={(e) => e.stopPropagation()}>
+                <div className="calendar-modal-header">
+                    <h2>{series.label}</h2>
+                    <button className="close-button" onClick={onClose}>✕</button>
+                </div>
+
+                <div className="calendar-modal-content">
+                    <p>Select sessions to add to your calendar. Sessions will repeat weekly for 1 year from today.</p>
+
+                    <div className="select-buttons">
+                        <button onClick={selectAll}>Select All</button>
+                        <button onClick={selectNone}>Select None</button>
+                    </div>
+
+                    <div className="sessions-list">
+                        {series.sessions.map(session => {
+                            const sessionId = getSessionId(session);
+                            const isSelected = selectedSessions.has(sessionId);
+                            const timeInfo = localTimeInfoMap.get(sessionId);
+
+                            return (
+                                <label key={sessionId} className="session-item">
+                                    <input
+                                        type="checkbox"
+                                        checked={isSelected}
+                                        onChange={() => toggleSession(sessionId)}
+                                    />
+                                    <span className="session-info">
+                                        {timeInfo.dayName} {timeInfo.time}
+                                        {session.notes && session.notes.length > 0 && (
+                                            <span className="session-notes"> • {session.notes.join(', ')}</span>
+                                        )}
+                                    </span>
+                                </label>
+                            );
+                        })}
+                    </div>
+                </div>
+
+                <div className="calendar-modal-footer">
+                    <button
+                        className="download-button"
+                        onClick={handleDownload}
+                        disabled={selectedSessions.size === 0}
+                    >
+                        <CalendarIcon className="button-icon" /> Download Calendar ({selectedSessions.size} session{selectedSessions.size !== 1 ? 's' : ''})
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default CalendarModal;

--- a/src/components/CalendarModal/CalendarModal.scss
+++ b/src/components/CalendarModal/CalendarModal.scss
@@ -1,0 +1,224 @@
+@import '../../_global.scss';
+
+// Calendar link button (used in App.js)
+.calendar-link-button {
+    background: none;
+    border: none;
+    color: $text-primary;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+    display: inline-block;
+    margin-inline-end: 0.4em;
+    text-decoration: underline;
+
+    &:hover {
+        color: $text-primary;
+    }
+}
+
+.calendar-modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.9);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 1rem;
+}
+
+.calendar-modal {
+    background: $background-primary;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: $border-radius;
+    max-width: 600px;
+    width: 100%;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    color: $text-primary;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+
+    .calendar-modal-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 1rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+
+        h2 {
+            margin: 0;
+            font-size: 5.7vw;
+            color: $text-primary;
+            font-weight: 900;
+
+            @media (min-width: $medium-width) {
+                font-size: 30px;
+            }
+        }
+
+        .close-button {
+            background: none;
+            border: none;
+            color: $text-primary;
+            font-size: 6vw;
+            cursor: pointer;
+            padding: 0;
+            line-height: 1;
+            opacity: 0.7;
+
+            @media (min-width: $medium-width) {
+                font-size: 30px;
+            }
+
+            &:hover {
+                opacity: 1;
+            }
+        }
+    }
+
+    .calendar-modal-content {
+        padding: 1rem;
+        overflow-y: auto;
+        flex: 1;
+
+        p {
+            margin: 0 0 1rem 0;
+            font-size: 3.3vw;
+
+            @media (min-width: $medium-width) {
+                font-size: 14px;
+            }
+        }
+
+        .select-buttons {
+            display: flex;
+            gap: 0.33em;
+            margin-bottom: 1rem;
+
+            button {
+                display: inline-block;
+                padding: 0 0.5em;
+                line-height: 1.5em;
+                height: 1.5em;
+                font-size: 4.4vw;
+                border-radius: $border-radius;
+                font-weight: 500;
+                background-color: rgb(26, 26, 26);
+                color: $text-primary;
+                border: none;
+                cursor: pointer;
+
+                @media (min-width: $medium-width) {
+                    font-size: 20px;
+                }
+
+                &:hover {
+                    color: $background-primary;
+                    background-color: $text-primary;
+                }
+            }
+        }
+
+        .sessions-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.33em;
+
+            .session-item {
+                display: flex;
+                align-items: center;
+                gap: 0.5em;
+                padding: 0.5em;
+                background: transparent;
+                cursor: pointer;
+
+                &:hover {
+                    background: rgba(255, 255, 255, 0.05);
+                }
+
+                input[type="checkbox"] {
+                    width: 1.2em;
+                    height: 1.2em;
+                    cursor: pointer;
+                    flex-shrink: 0;
+                }
+
+                .session-info {
+                    flex: 1;
+                    font-size: 4vw;
+                    line-height: 1.5;
+
+                    @media (min-width: $medium-width) {
+                        font-size: 18px;
+                    }
+
+                    .session-notes {
+                        opacity: 0.6;
+                        font-size: 0.9em;
+                    }
+                }
+            }
+        }
+    }
+
+    .calendar-modal-footer {
+        padding: 1rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.1);
+        display: flex;
+        justify-content: center;
+
+        .download-button {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.4em;
+            padding: 0 0.5em;
+            line-height: 1.5em;
+            height: 1.5em;
+            font-size: 4.4vw;
+            border-radius: $border-radius;
+            font-weight: 500;
+            background-color: rgb(26, 26, 26);
+            color: $text-primary;
+            border: none;
+            cursor: pointer;
+
+            @media (min-width: $medium-width) {
+                font-size: 20px;
+            }
+
+            .button-icon {
+                width: 0.9em;
+                height: 0.9em;
+                flex-shrink: 0;
+
+                path {
+                    fill: $text-primary;
+                }
+            }
+
+            &:hover:not(:disabled) {
+                color: $background-primary;
+                background-color: $text-primary;
+
+                .button-icon path {
+                    fill: $background-primary;
+                }
+            }
+
+            &:disabled {
+                background-color: rgb(20, 20, 20);
+                color: rgb(80, 80, 80);
+                cursor: not-allowed;
+
+                .button-icon path {
+                    fill: rgb(80, 80, 80);
+                }
+            }
+        }
+    }
+}

--- a/src/images/calendar.svg
+++ b/src/images/calendar.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M19 4h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V10h14v10zM9 14H7v-2h2v2zm4 0h-2v-2h2v2zm4 0h-2v-2h2v2zm-8 4H7v-2h2v2zm4 0h-2v-2h2v2zm4 0h-2v-2h2v2z"/>
+</svg>

--- a/src/lib/calendar-helpers.js
+++ b/src/lib/calendar-helpers.js
@@ -1,0 +1,179 @@
+import moment from 'moment-timezone';
+
+// ICS format constants
+const ICAL_DAY_MAP = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+const EVENT_DURATION = 'PT1H'; // 1 hour in ISO 8601 duration format
+const CALENDAR_REPEAT_YEARS = 1;
+
+/**
+ * Checks if a session is marked as special (Broadcasted or SOF)
+ * @param {Object} session - Session object with notes array
+ * @returns {boolean} True if session has Broadcasted or SOF notes
+ */
+export const isSpecialSession = (session) => {
+    if (!session.notes || session.notes.length === 0) return false;
+    return session.notes.some(note => {
+        const lower = note.toLowerCase();
+        return lower.includes('broadcasted') || lower.includes('sof');
+    });
+};
+
+const getSessionId = (session) => `${session.sessionDay}-${session.sessionTimeGmt}`;
+
+/**
+ * Parses time string into hour and minute components
+ * @param {string} timeString - Time in HH:MM format
+ * @returns {Object} Object with hour and minute properties
+ */
+export const parseTime = (timeString) => {
+    const [hour, minute] = timeString.split(':').map(Number);
+    return { hour, minute };
+};
+
+/**
+ * Converts day of week to ISO weekday format (Sunday: 0→7)
+ * @param {number} day - Day of week (0=Sunday, 1=Monday, ..., 6=Saturday)
+ * @returns {number} ISO weekday (1=Monday, ..., 7=Sunday)
+ */
+export const toIsoWeekday = (day) => day === 0 ? 7 : day;
+
+const getSessionTags = (session) => {
+    const tags = [];
+    if (!session.notes) return tags;
+
+    const hasBroadcasted = session.notes.some(note => note.toLowerCase().includes('broadcasted'));
+    const hasSOF = session.notes.some(note => note.toLowerCase().includes('sof'));
+
+    if (hasBroadcasted) tags.push('Broadcasted');
+    if (hasSOF) tags.push('SOF');
+
+    return tags;
+};
+
+/**
+ * Calculates the next occurrence of a weekly session
+ * @param {number} sessionDay - Day of week (0=Sunday, 1=Monday, ..., 6=Saturday)
+ * @param {string} sessionTime - Time in HH:MM format
+ * @returns {moment.Moment} Next occurrence in GMT
+ */
+export const getNextOccurrence = (sessionDay, sessionTime) => {
+    const now = moment.tz('GMT');
+    const { hour, minute } = parseTime(sessionTime);
+
+    let next = now.clone()
+        .isoWeekday(toIsoWeekday(sessionDay))
+        .hour(hour)
+        .minute(minute)
+        .second(0)
+        .millisecond(0);
+
+    if (next.isBefore(now)) {
+        next.add(1, 'week');
+    }
+
+    return next;
+};
+
+/**
+ * Builds the event description text for ICS calendar
+ * @param {Object} series - Series object with label, cars, and links
+ * @param {Object} session - Session object with notes
+ * @returns {string} Formatted description text
+ */
+export const buildDescription = (series, session) => {
+    const parts = [];
+
+    parts.push(series.label);
+    parts.push(`Cars: ${series.cars.join(', ')}`);
+
+    if (session.notes && session.notes.length > 0) {
+        parts.push(`Notes: ${session.notes.join(', ')}`);
+    }
+
+    if (series.links) {
+        const links = ['Links:'];
+        if (series.links.discord) links.push(`Discord: ${series.links.discord}`);
+        if (series.links.website) links.push(`Website: ${series.links.website}`);
+        if (series.links.broadcast) links.push(`Broadcast: ${series.links.broadcast}`);
+        parts.push(links.join('\n'));
+    }
+
+    parts.push(`Full schedule: https://whenrace.com/${series.seriesId}`);
+
+    return parts.join('\n\n');
+};
+
+/**
+ * Generates an ICS calendar file content for selected sessions
+ * @param {Object} series - Series object with sessions and metadata
+ * @param {Set<string>} selectedSessionIds - Set of session IDs to include
+ * @returns {string} ICS calendar file content
+ * @throws {Error} If no sessions are selected
+ */
+export const generateCalendar = (series, selectedSessionIds) => {
+    if (!selectedSessionIds || selectedSessionIds.size === 0) {
+        throw new Error('Please select at least one session');
+    }
+
+    const lines = [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'CALSCALE:GREGORIAN',
+        'PRODID:whenrace.com',
+        'METHOD:PUBLISH',
+        'X-PUBLISHED-TTL:PT1H'
+    ];
+
+    // Set calendar to repeat for the configured duration
+    const untilDate = moment.tz('GMT').add(CALENDAR_REPEAT_YEARS, 'year');
+
+    series.sessions.forEach((session) => {
+        if (!selectedSessionIds.has(getSessionId(session))) return;
+
+        const startMoment = getNextOccurrence(session.sessionDay, session.sessionTimeGmt);
+
+        // Build event name with special session indicators
+        const tags = getSessionTags(session);
+        const eventName = tags.length > 0
+            ? `${series.label} – ${tags.join(', ')}`
+            : `${series.label} – Official Session`;
+
+        lines.push('BEGIN:VEVENT');
+        lines.push(`UID:${series.seriesId}-${getSessionId(session)}@whenrace.com`);
+        lines.push(`SUMMARY:${eventName}`);
+        lines.push(`DTSTAMP:${moment().format('YYYYMMDDTHHmmss')}Z`);
+        lines.push(`DTSTART:${startMoment.format('YYYYMMDDTHHmmss')}Z`);
+        lines.push(`DESCRIPTION:${buildDescription(series, session).replace(/\n/g, '\\n')}`);
+        lines.push(`URL:https://whenrace.com/${series.seriesId}`);
+        lines.push('STATUS:CONFIRMED');
+        lines.push('CATEGORIES:iRacing,Sim Racing');
+        lines.push('X-MICROSOFT-CDO-BUSYSTATUS:FREE');
+        lines.push(`RRULE:FREQ=WEEKLY;UNTIL=${untilDate.format('YYYYMMDDTHHmmss')}Z;BYDAY=${ICAL_DAY_MAP[session.sessionDay]}`);
+        lines.push(`DURATION:${EVENT_DURATION}`);
+        lines.push('END:VEVENT');
+    });
+
+    lines.push('END:VCALENDAR');
+
+    return lines.join('\r\n');
+};
+
+/**
+ * Generates and downloads an ICS calendar file for selected sessions
+ * @param {Object} series - Series object with sessions and metadata
+ * @param {Set<string>} selectedSessionIds - Set of session IDs to include
+ * @throws {Error} If calendar generation or download fails
+ */
+export const downloadCalendar = (series, selectedSessionIds) => {
+    const icsContent = generateCalendar(series, selectedSessionIds);
+
+    const blob = new Blob([icsContent], { type: 'text/calendar;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `whenrace-${series.seriesId}.ics`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+};

--- a/src/lib/calendar-helpers.js
+++ b/src/lib/calendar-helpers.js
@@ -147,7 +147,7 @@ export const generateCalendar = (series, selectedSessionIds) => {
         lines.push(`URL:https://whenrace.com/${series.seriesId}`);
         lines.push('STATUS:CONFIRMED');
         lines.push('CATEGORIES:iRacing,Sim Racing');
-        lines.push('X-MICROSOFT-CDO-BUSYSTATUS:FREE');
+        lines.push('X-MICROSOFT-CDO-BUSYSTATUS:BUSY');
         lines.push(`RRULE:FREQ=WEEKLY;UNTIL=${untilDate.format('YYYYMMDDTHHmmss')}Z;BYDAY=${ICAL_DAY_MAP[session.sessionDay]}`);
         lines.push(`DURATION:${EVENT_DURATION}`);
         lines.push('END:VEVENT');


### PR DESCRIPTION
## Summary

Users can now download iCalendar (.ics) files for any race series to import schedules into their calendar apps.

## Key Features

- Click "Download calendar" to select which sessions to add
- Auto-selects Broadcasted and SOF sessions by default
- Shows times in your local timezone
- Creates weekly recurring events for 1 year

## Implementation

- Minimal changes to existing files (36 lines in App.js, 0 changes to App.scss)
- New CalendarModal component with session selection UI
- ICS file generation following RFC 5545 standard

## Demo

https://github.com/user-attachments/assets/5e5390f1-3883-4144-8864-d1de568519fe
