### PR TITLE
Added second Clio Cup SOF race at 02:00 Thursday (20:00 Wednesday CST)

### DIFF
--- a/src/data/official-sessions.js
+++ b/src/data/official-sessions.js
@@ -81,6 +81,11 @@ const officials = [
                 sessionTimeGmt: '20:00',
                 notes: [SOF]
             },
+            {
+                sessionDay: THU,
+                sessionTimeGmt: '02:00',
+                notes: [SOF]
+            },
         ]
     },
     {


### PR DESCRIPTION
Addition of the new SOF of the Americas (SoFotA) for Clio Cup.